### PR TITLE
Expand mobile nav breakpoint

### DIFF
--- a/header/style.css
+++ b/header/style.css
@@ -131,7 +131,7 @@
 }
 
 /* -------- Breakpoints -------- */
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
   .primary-nav,
   .header-cta {
     display: none;


### PR DESCRIPTION
## Summary
- expand the mobile hamburger breakpoint to 1024px so navigation collapses on tablet

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6866bbce15b08330acef7e1df7168cd8