### PR TITLE
Inline hero section in index

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,18 @@
   <link rel="stylesheet" href="style/buttons.css">
   <link rel="stylesheet" href="style/forms.css">
   <link rel="stylesheet" href="style/animations.css">
+  <link rel="stylesheet" href="sections/hero/style.css">
 </head>
 <body>
   <div id="header-placeholder"></div>
-  <div id="hero-placeholder"></div>
+  <section class="hero-section">
+    <img class="hero-bg" src="images/index-hero.png" alt="" />
+    <div class="hero-content">
+      <h1>Bespoke Kitchens & Interiors, Crafted for Life.</h1>
+      <p>Discover a seamless journey to a space that is uniquely yours.</p>
+      <a href="/contact.html" class="btn btn--primary">Begin Your Journey</a>
+    </div>
+  </section>
   <div id="footer-placeholder"></div>
   <script>
     function loadPartial(url, placeholderId) {
@@ -53,7 +61,6 @@
         .catch(err => console.error('Failed to load', url, err));
     }
     loadPartial('header/header.html', 'header-placeholder');
-    loadPartial('sections/hero/hero.html', 'hero-placeholder');
     loadPartial('footer/footer.html', 'footer-placeholder');
   </script>
 </body>

--- a/sections/hero/hero.html
+++ b/sections/hero/hero.html
@@ -8,6 +8,7 @@
      ========================================================== -->
 
 <section class="hero-section">
+  <img class="hero-bg" src="/images/index-hero.png" alt="" />
   <div class="hero-content">
     <h1>Bespoke Kitchens & Interiors, Crafted for Life.</h1>
     <p>Discover a seamless journey to a space that is uniquely yours.</p>

--- a/sections/hero/style.css
+++ b/sections/hero/style.css
@@ -1,6 +1,5 @@
 .hero-section {
   position: relative;
-  background: url('/images/index-hero.png') center/cover no-repeat;
   color: var(--c-surface);
   min-height: 100vh;
   display: flex;
@@ -8,6 +7,16 @@
   justify-content: center;
   text-align: center;
   padding: var(--space-700) var(--space-400);
+  overflow: hidden;
+}
+
+.hero-section img.hero-bg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: -1;
 }
 
 .hero-section::before {


### PR DESCRIPTION
## Summary
- embed hero section HTML directly in `index.html`
- keep hero styles as external CSS and add `<img>` element for the background

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866de0507f88330b2cc3752a23f39e8