### PR TITLE
Enhance hero readability and hamburger

### DIFF
--- a/header/style.css
+++ b/header/style.css
@@ -79,6 +79,8 @@
   height: calc(var(--line-h) * 3 + var(--gap) * 2);
   display: none; /* hidden on desktop */
   cursor: pointer;
+  background: none;
+  border: none;
 }
 .hamburger span {
   display: block;

--- a/sections/hero/style.css
+++ b/sections/hero/style.css
@@ -23,13 +23,14 @@
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.35);
+  background: rgba(0, 0, 0, 0.45);
 }
 
 .hero-content {
   position: relative;
   max-width: 800px;
   z-index: 1;
+  color: var(--c-surface);
 }
 
 .hero-content h1 {
@@ -37,12 +38,18 @@
   font-size: clamp(2rem, 5vw, 4rem);
   line-height: 1.1;
   margin-bottom: var(--space-400);
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
 }
 
 .hero-content p {
   font-family: var(--font-sans);
   font-size: clamp(1rem, 2.5vw, 1.25rem);
   margin-bottom: var(--space-500);
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+}
+
+.hero-content a {
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- darken hero overlay for legibility
- use consistent white hero text with shadow
- ensure hamburger button has no grey background

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866e032303c8330a660fe992e76b758