### PR TITLE
Fix hero and statement spacing

### DIFF
--- a/sections/hero/style.css
+++ b/sections/hero/style.css
@@ -6,7 +6,8 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: var(--space-700) var(--space-400);
+  /* use base spacing variables for consistent vertical rhythm */
+  padding: var(--space-7) var(--space-4);
   overflow: hidden;
 }
 
@@ -37,14 +38,14 @@
   font-family: var(--font-serif);
   font-size: clamp(2rem, 5vw, 4rem);
   line-height: 1.1;
-  margin-bottom: var(--space-400);
+  margin-bottom: var(--space-4);
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
 }
 
 .hero-content p {
   font-family: var(--font-sans);
   font-size: clamp(1rem, 2.5vw, 1.25rem);
-  margin-bottom: var(--space-500);
+  margin-bottom: var(--space-5);
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
 }
 
@@ -54,7 +55,7 @@
 
 @media (max-width: 768px) {
   .hero-section {
-    padding: var(--space-600) var(--space-300);
+    padding: var(--space-6) var(--space-3);
     min-height: 80vh;
   }
 }

--- a/sections/statement/style.css
+++ b/sections/statement/style.css
@@ -8,7 +8,8 @@
 .crafted-statement {
   background: var(--c-bg);
   color: var(--c-text);
-  padding-block: var(--space-700);
+  /* correct spacing variable names */
+  padding-block: var(--space-7);
   text-align: center;
   display: flex;
   align-items: center;
@@ -17,25 +18,25 @@
 
 .statement-inner {
   max-width: 42rem;
-  padding-inline: var(--space-400);
+  padding-inline: var(--space-4);
 }
 
 .crafted-statement h2 {
   font-family: var(--font-serif);
   font-size: clamp(2rem, 5vw, 3rem);
   line-height: 1.15;
-  margin-bottom: var(--space-400);
+  margin-bottom: var(--space-4);
 }
 
 .crafted-statement p {
   font-family: var(--font-sans);
   font-size: clamp(1rem, 2.25vw, 1.125rem);
   line-height: 1.55;
-  margin-bottom: var(--space-500);
+  margin-bottom: var(--space-5);
 }
 
 @media (min-width: 48rem) {
   .crafted-statement {
-    padding-block: var(--space-800);
+    padding-block: var(--space-8);
   }
 }


### PR DESCRIPTION
## Summary
- use existing --space-* variables in hero and statement CSS
- ensure headings and paragraphs get margin from base spacing scale

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866e76497ec833099a5240083681bb5