### PR TITLE
Fix hero text contrast and button styles

### DIFF
--- a/sections/hero/style.css
+++ b/sections/hero/style.css
@@ -24,7 +24,11 @@
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.45);
+  /* slightly stronger gradient for readability */
+  background: linear-gradient(
+      rgba(0, 0, 0, 0.6),
+      rgba(0, 0, 0, 0.45)
+  );
 }
 
 .hero-content {
@@ -39,14 +43,16 @@
   font-size: clamp(2rem, 5vw, 4rem);
   line-height: 1.1;
   margin-bottom: var(--space-4);
-  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  color: #fff;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
 }
 
 .hero-content p {
   font-family: var(--font-sans);
   font-size: clamp(1rem, 2.5vw, 1.25rem);
   margin-bottom: var(--space-5);
-  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  color: #fff;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
 }
 
 .hero-content a {

--- a/style/buttons.css
+++ b/style/buttons.css
@@ -15,13 +15,14 @@
   gap: var(--space-200);
   font-family: var(--font-sans);
   font-size: var(--fs-400);
+  line-height: 1.2;
   letter-spacing: 0.02em;
   font-weight: 500;
   text-decoration: none;
   cursor: pointer;
   border: none;
-  border-radius: var(--radius-md);
-  padding: var(--space-300) var(--space-500);
+  border-radius: 6px;
+  padding: 0.75rem 1.5rem;
   transition: background 0.3s ease, color 0.3s ease, transform 0.2s ease;
 }
 
@@ -33,7 +34,7 @@
 
 .btn--primary:hover,
 .btn--primary:focus {
-  background: var(--c-accent-hover);
+  background: var(--c-accent-light);
   transform: translateY(-2px);
 }
 


### PR DESCRIPTION
## Summary
- strengthen hero overlay gradient for clarity
- set hero heading and paragraph color to white with subtle shadow
- refine base `.btn` padding, radius, and line-height
- correct primary button hover color variable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866ea776d8483308ab0501a8b7051c5