### PR TITLE
Fix mobile navigation drawer z-index

### DIFF
--- a/header/header.html
+++ b/header/header.html
@@ -46,7 +46,7 @@
     </header>
 
     <!-- Mobile nav drawer -->
-    <nav class="mobile-nav" aria-label="Mobile Navigation" data-js="mobile-nav">
+    <nav id="mobile-drawer" class="mobile-nav" aria-label="Mobile Navigation" data-js="mobile-nav">
       <a href="index.html">Home</a>
       <a href="portfolio.html">Portfolio</a>
       <a href="services.html">Services</a>

--- a/header/style.css
+++ b/header/style.css
@@ -34,6 +34,8 @@
   color: var(--c-accent);
   letter-spacing: 0.015em;
   text-decoration: none;
+  position: relative;
+  z-index: 1400;
 }
 
 /* -------- Nav -------- */
@@ -81,6 +83,8 @@
   cursor: pointer;
   background: none;
   border: none;
+  position: relative;
+  z-index: 1400;
 }
 .hamburger span {
   display: block;
@@ -102,13 +106,17 @@
 }
 .hamburger.is-active span:nth-child(3) {
   transform: translateY(calc(-1 * (var(--gap) + var(--line-h)))) rotate(-45deg);
+} 
+
+body.no-scroll {
+  overflow: hidden;
 }
 
 /* -------- Mobile menu (drawer) -------- */
-.mobile-nav {
+#mobile-drawer {
   position: fixed;
   inset: 0;
-  z-index: 1100;
+  z-index: 1300;
   background: var(--c-bg);
   display: flex;
   flex-direction: column;
@@ -118,10 +126,10 @@
   transform: translateX(100%);
   transition: transform 0.5s ease;
 }
-.mobile-nav.is-open {
+#mobile-drawer.is-open {
   transform: translateX(0);
 }
-.mobile-nav a {
+#mobile-drawer a {
   font-family: "Inter", sans-serif;
   font-size: 1.25rem; /* 20px */
   letter-spacing: 0.08em;
@@ -129,7 +137,7 @@
   text-decoration: none;
   color: var(--c-text);
 }
-.mobile-nav .btn {
+#mobile-drawer .btn {
   margin-top: 2rem;
 }
 


### PR DESCRIPTION
## Summary
- ensure logo and hamburger stay above drawer
- add `#mobile-drawer` id with higher z-index to overlay header
- prevent background scrolling when drawer is open

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866ed7099908330bb00f0f89698b633