### PR TITLE
Enable swipe right gesture to close mobile nav

### DIFF
--- a/header/header.html
+++ b/header/header.html
@@ -69,6 +69,28 @@
           document.body.classList.toggle('no-scroll');
         });
 
+        // Close drawer on swipe right
+        let startX = 0;
+        mobileNav.addEventListener(
+          'touchstart',
+          e => {
+            startX = e.touches[0].clientX;
+          },
+          { passive: true }
+        );
+        mobileNav.addEventListener(
+          'touchend',
+          e => {
+            const endX = e.changedTouches[0].clientX;
+            if (endX - startX > 50) {
+              burger.classList.remove('is-active');
+              mobileNav.classList.remove('is-open');
+              document.body.classList.remove('no-scroll');
+            }
+          },
+          { passive: true }
+        );
+
         // Scroll elevation effect
         window.addEventListener('scroll', () => {
           const curr = window.scrollY;


### PR DESCRIPTION
## Summary
- allow swiping right to close the mobile drawer navigation

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866efc3248c8330a8d72b5493c658b3