### PR TITLE
Fix mobile nav close icon visibility

### DIFF
--- a/header/style.css
+++ b/header/style.css
@@ -7,7 +7,8 @@
 .site-header {
   position: sticky;
   top: 0;
-  z-index: 1000;
+  /* Ensure header and its children sit above the mobile drawer */
+  z-index: 1400;
   background-color: var(--c-bg);
   padding-block: 0.75rem; /* 12px */
   transition: box-shadow 0.3s ease;


### PR DESCRIPTION
## Summary
- raise site header `z-index` so the hamburger close icon stays above the mobile drawer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866f311a4808330a7a8999199704df1