### PR TITLE
Fix carousel logic and add CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,8 +67,7 @@
         </article>
       </div>
       <div class="carousel-controls">
-        <button class="carousel-btn" data-js="carousel-prev" aria-label="Previous">&#10094;</button>
-        <button class="carousel-btn" data-js="carousel-next" aria-label="Next">&#10095;</button>
+        <a href="/portfolio.html" class="btn btn--primary">View Portfolio</a>
       </div>
     </div>
   </section>
@@ -112,28 +111,23 @@
     loadPartial('footer/footer.html', 'footer-placeholder');
 
     const track = document.querySelector('[data-js="signature-track"]');
-    const prev = document.querySelector('[data-js="carousel-prev"]');
-    const next = document.querySelector('[data-js="carousel-next"]');
     if (track) {
-      const slideWidth = () => track.clientWidth;
-      prev.addEventListener('click', () => {
-        track.scrollBy({ left: -slideWidth(), behavior: 'smooth' });
-      });
-      next.addEventListener('click', () => {
-        track.scrollBy({ left: slideWidth(), behavior: 'smooth' });
-      });
+      const slide = track.querySelector('.carousel-slide');
+      const gap = parseFloat(getComputedStyle(track).gap) || 0;
+      const slideWidth = () => slide.clientWidth + gap;
+      function scrollByAmount(amount) {
+        const max = track.scrollWidth - track.clientWidth;
+        const dest = Math.min(Math.max(track.scrollLeft + amount, 0), max);
+        track.scrollTo({ left: dest, behavior: 'smooth' });
+      }
       let startX = 0;
       track.addEventListener('touchstart', e => {
         startX = e.touches[0].clientX;
       }, { passive: true });
       track.addEventListener('touchend', e => {
         const delta = startX - e.changedTouches[0].clientX;
-        if (delta > 50) {
-          track.scrollBy({ left: slideWidth(), behavior: 'smooth' });
-        }
-        if (delta < -50) {
-          track.scrollBy({ left: -slideWidth(), behavior: 'smooth' });
-        }
+        if (delta > 50) scrollByAmount(slideWidth());
+        if (delta < -50) scrollByAmount(-slideWidth());
       }, { passive: true });
     }
   </script>

--- a/sections/signature-carousel/style.css
+++ b/sections/signature-carousel/style.css
@@ -56,19 +56,6 @@
   justify-content: center;
   gap: var(--space-4);
 }
-.signature-carousel .carousel-btn {
-  background: var(--c-accent);
-  color: var(--c-surface);
-  border: none;
-  border-radius: var(--radius-md);
-  padding: 0.5rem 1rem;
-  font-size: 1.25rem;
-  cursor: pointer;
-  transition: background 0.3s ease;
-}
-.signature-carousel .carousel-btn:hover {
-  background: var(--c-accent-light);
-}
 @media (min-width: 48rem) {
   .signature-carousel .carousel-slide {
     flex: 0 0 calc(50% - var(--space-6));


### PR DESCRIPTION
## Summary
- remove arrow navigation from the Signature Collection carousel
- add a primary CTA button linking to the portfolio
- improve scroll logic to include slide gap and clamp scrolling
- clean up unused carousel button styles

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686769d3d1a88330bc6d39ff1ae87715