### PR TITLE
Add left gutter to signature carousel

### DIFF
--- a/sections/signature-carousel/style.css
+++ b/sections/signature-carousel/style.css
@@ -29,6 +29,15 @@
   -webkit-overflow-scrolling: touch;
   scroll-behavior: smooth;
   scrollbar-width: none; /* Firefox */
+  padding-inline-start: 5%; /* subtle gutter on mobile/tablet */
+  scroll-padding-left: 5%;
+}
+
+@media (min-width: 64rem) {
+  .signature-carousel .carousel-track {
+    padding-inline-start: 0;
+    scroll-padding-left: 0;
+  }
 }
 .signature-carousel .carousel-track::-webkit-scrollbar {
   display: none;


### PR DESCRIPTION
## Summary
- add 5% left padding to the signature carousel track
- reset that gutter on desktop screens
- keep existing slide widths for mobile, tablet and desktop

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686facac11548330a997b19e1657d529