### PR TITLE
Improve signature carousel interaction

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,14 +176,43 @@
 
     const track = document.querySelector('[data-js="signature-track"]');
     if (track) {
-      const slide = track.querySelector('.carousel-slide');
+      const slides = Array.from(track.querySelectorAll('.carousel-slide'));
+      const dots = Array.from(document.querySelectorAll('.carousel-dots .dot'));
       const gap = parseFloat(getComputedStyle(track).gap) || 0;
-      const slideWidth = () => slide.clientWidth + gap;
+
+      function setPadding() {
+        const slide = slides[0];
+        const offset = (track.clientWidth - slide.clientWidth) / 2;
+        track.style.paddingLeft = offset + 'px';
+        track.style.paddingRight = offset + 'px';
+      }
+      setPadding();
+      window.addEventListener('resize', setPadding);
+
+      const slideWidth = () => slides[0].clientWidth + gap;
       function scrollByAmount(amount) {
         const max = track.scrollWidth - track.clientWidth;
         const dest = Math.min(Math.max(track.scrollLeft + amount, 0), max);
         track.scrollTo({ left: dest, behavior: 'smooth' });
       }
+      function updateDots() {
+        const center = track.scrollLeft + track.clientWidth / 2;
+        let closest = 0;
+        let minDist = Infinity;
+        slides.forEach((s, idx) => {
+          const sCenter = s.offsetLeft + s.clientWidth / 2;
+          const dist = Math.abs(center - sCenter);
+          if (dist < minDist) {
+            minDist = dist;
+            closest = idx;
+          }
+        });
+        dots.forEach((d, i) => d.classList.toggle('active', i === closest));
+      }
+      track.addEventListener('scroll', updateDots);
+      window.addEventListener('resize', updateDots);
+      updateDots();
+
       let startX = 0;
       track.addEventListener('touchstart', e => {
         startX = e.touches[0].clientX;

--- a/sections/signature-carousel/style.css
+++ b/sections/signature-carousel/style.css
@@ -29,14 +29,11 @@
   -webkit-overflow-scrolling: touch;
   scroll-behavior: smooth;
   scrollbar-width: none; /* Firefox */
-  padding-inline-start: 5%; /* subtle gutter on mobile/tablet */
-  scroll-padding-left: 5%;
 }
 
 @media (min-width: 64rem) {
   .signature-carousel .carousel-track {
     padding-inline-start: 0;
-    scroll-padding-left: 0;
   }
 }
 .signature-carousel .carousel-track::-webkit-scrollbar {
@@ -44,7 +41,7 @@
 }
 .signature-carousel .carousel-slide {
   flex: 0 0 85%; /* Shows most of 1 slide + peek of next on mobile */
-  scroll-snap-align: start;
+  scroll-snap-align: center;
 }
 
 @media (min-width: 48rem) {


### PR DESCRIPTION
## Summary
- highlight dots based on centred slide
- adjust layout so slides snap to centre and end spacing allows centring

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686fae639b18833089c16a28930d9e80