### PR TITLE
Fix carousel padding adjustments and logo path

### DIFF
--- a/header/header.html
+++ b/header/header.html
@@ -24,7 +24,7 @@
       <div class="header-inner">
         <!-- Logo -->
         <a href="index.html" class="logo">
-          <img src="images/cove-bespoke-logo.png" alt="Cove Bespoke Logo" height="60">
+          <img src="./images/cove-bespoke-logo.png" alt="Cove Bespoke Logo" height="60">
         </a>
 
         <!-- Primary navigation (desktop) -->

--- a/index.html
+++ b/index.html
@@ -188,6 +188,7 @@
       }
       setPadding();
       window.addEventListener('resize', setPadding);
+      window.addEventListener('scroll', setPadding, { passive: true });
 
       const slideWidth = () => slides[0].clientWidth + gap;
       function scrollByAmount(amount) {

--- a/sections/hero/style.css
+++ b/sections/hero/style.css
@@ -2,7 +2,7 @@
   position: relative;
   color: var(--c-surface);
   min-height: 100vh;
-  min-height: 100dvh;
+  min-height: 100svh;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -64,6 +64,6 @@
   .hero-section {
     padding: var(--space-6) var(--space-3);
     min-height: 80vh;
-    min-height: 80dvh;
+    min-height: 80svh;
   }
 }


### PR DESCRIPTION
## Summary
- ensure header logo loads with local path
- use `svh` units for hero section to stop layout jump on scroll
- recalc carousel padding on scroll to keep consistent width

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_686fb5bdaee48330b1727b029bb05dd8