### PR TITLE
Fix shrinking carousel height

### DIFF
--- a/sections/signature-carousel/style.css
+++ b/sections/signature-carousel/style.css
@@ -4,6 +4,7 @@
   /* take up the full viewport height so no vertical scrolling is needed */
   min-height: 100vh;
   min-height: 100svh;
+  min-height: 100dvh; /* dynamic height to avoid shrinking on scroll */
   display: flex;
   align-items: center;
 }


### PR DESCRIPTION
## Summary
- prevent `signature-carousel` from shrinking when browser UI collapses by using `min-height: 100dvh`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686fbb3083008330ae793489daec8c53