### PR TITLE
Fix carousel heading overflow

### DIFF
--- a/sections/signature-carousel/style.css
+++ b/sections/signature-carousel/style.css
@@ -101,6 +101,8 @@
   font-family: var(--font-serif);
   font-size: var(--fs-700);
   margin-bottom: var(--space-2);
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 .signature-carousel__text p {
   font-family: var(--font-sans);


### PR DESCRIPTION
## Summary
- allow carousel slide headings to wrap so long titles don't stretch the viewport

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fd262b4b08330b6191572cbdc44c9