### PR TITLE
Fix desktop carousel width

### DIFF
--- a/sections/signature-carousel/style.css
+++ b/sections/signature-carousel/style.css
@@ -43,7 +43,6 @@
 }
 @media (min-width: 48rem) {
   .signature-carousel__inner {
-    max-width: 60rem;             /* 960 px container */
     margin-inline: auto;
     padding-inline: var(--space-4);
   }


### PR DESCRIPTION
## Summary
- remove max-width restriction on carousel container so desktop images span the full screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870d20a2d1883309ec8fefe9d74f118