### PR TITLE
Add intro banner section to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="style/forms.css">
   <link rel="stylesheet" href="style/animations.css">
   <link rel="stylesheet" href="sections/hero/style.css">
+  <link rel="stylesheet" href="sections/intro-banner/style.css">
 </head>
 <body>
   <div id="header-placeholder"></div>
@@ -22,6 +23,13 @@
       <h1>Bespoke Kitchens & Interiors, Crafted for Life.</h1>
       <p>Discover a seamless journey to a space that is uniquely yours.</p>
       <a href="/contact.html" class="btn btn--primary">Begin Your Journey</a>
+    </div>
+  </section>
+  <section class="intro-banner">
+    <div class="intro-banner__content">
+      <h2>Crafted Without Compromise</h2>
+      <p>At Cove Bespoke, every kitchen and interior is made to order — designed around your space, lifestyle, and personal vision. From our workshop in County Wicklow, we create handmade pieces using time-honoured techniques, modern digital design tools, and a deep respect for quality. Every element is built from scratch, sprayed in-house, and finished to exacting standards.</p>
+      <p>We work closely with homeowners, architects, and designers across Wicklow and surrounding areas, guiding each project from concept through to installation. Our process is collaborative, precise, and entirely tailored. The result is a space that feels uniquely yours — both beautifully functional and made to last.</p>
     </div>
   </section>
   <div id="footer-placeholder"></div>

--- a/sections/intro-banner/intro-banner.html
+++ b/sections/intro-banner/intro-banner.html
@@ -1,0 +1,15 @@
+<!-- ==========================================================
+     Cove Bespoke – Intro Banner Section
+     ----------------------------------------------------------
+     Simple centred copy block with headline and two paragraphs
+     ========================================================== -->
+
+<section class="intro-banner">
+  <div class="intro-banner__content">
+    <h2>Crafted Without Compromise</h2>
+    <p>At Cove Bespoke, every kitchen and interior is made to order — designed around your space, lifestyle, and personal vision. From our workshop in County Wicklow, we create handmade pieces using time-honoured techniques, modern digital design tools, and a deep respect for quality. Every element is built from scratch, sprayed in-house, and finished to exacting standards.</p>
+    <p>We work closely with homeowners, architects, and designers across Wicklow and surrounding areas, guiding each project from concept through to installation. Our process is collaborative, precise, and entirely tailored. The result is a space that feels uniquely yours — both beautifully functional and made to last.</p>
+  </div>
+</section>
+
+<link rel="stylesheet" href="sections/intro-banner/style.css" />

--- a/sections/intro-banner/style.css
+++ b/sections/intro-banner/style.css
@@ -1,0 +1,19 @@
+.intro-banner {
+  padding: var(--space-8) var(--space-4);
+  background-color: var(--c-surface);
+}
+
+.intro-banner__content {
+  max-width: 800px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.intro-banner__content h2 {
+  font-size: var(--fs-900);
+  margin-bottom: var(--space-5);
+}
+
+.intro-banner__content p {
+  margin-bottom: var(--space-4);
+}


### PR DESCRIPTION
## Summary
- Introduce reusable intro banner section and stylesheet
- Display crafted-without-compromise copy below hero on home page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892014a8f74833084df10e35fdceb49