### PR TITLE
Add intro banner section to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="style/forms.css">
   <link rel="stylesheet" href="style/animations.css">
   <link rel="stylesheet" href="sections/hero/style.css">
+  <link rel="stylesheet" href="sections/intro-banner/style.css">
 </head>
 <body>
   <div id="header-placeholder"></div>
@@ -22,6 +23,15 @@
       <h1>Bespoke Kitchens & Interiors, Crafted for Life.</h1>
       <p>Discover a seamless journey to a space that is uniquely yours.</p>
       <a href="/contact.html" class="btn btn--primary">Begin Your Journey</a>
+    </div>
+  </section>
+  <section class="intro-banner">
+    <div class="intro-banner__content">
+      <h1>Crafted Without Compromise</h1>
+      <div class="intro-banner__text-block">
+        <p>At Cove Bespoke, every kitchen and interior is made to order — designed around your space, lifestyle, and personal vision. From our workshop in County Wicklow, we create handmade pieces using time-honoured techniques, modern digital design tools, and a deep respect for quality. Every element is built from scratch, sprayed in-house, and finished to exacting standards.</p>
+        <p>We work closely with homeowners, architects, and designers across Wicklow and surrounding areas, guiding each project from concept through to installation. Our process is collaborative, precise, and entirely tailored. The result is a space that feels uniquely yours — both beautifully functional and made to last.</p>
+      </div>
     </div>
   </section>
   <div id="footer-placeholder"></div>


### PR DESCRIPTION
## Summary
- add intro banner section after hero on index
- include heading and two descriptive paragraphs highlighting brand essence and client reassurance
- load intro-banner stylesheet

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68920b3bf0988330aebde2993b7717ec