### PR TITLE
Add concept-to-completion media section

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="style/animations.css">
   <link rel="stylesheet" href="sections/hero/style.css">
   <link rel="stylesheet" href="sections/intro-banner/style.css">
+  <link rel="stylesheet" href="sections/media-left/style.css">
 </head>
 <body>
   <div id="header-placeholder"></div>
@@ -31,6 +32,33 @@
       <div class="intro-banner__text-block">
         <p>At Cove Bespoke, every kitchen and interior is made to order — designed around your space, lifestyle, and personal vision. From our workshop in County Wicklow, we create handmade pieces using time-honoured techniques, modern digital design tools, and a deep respect for quality. Every element is built from scratch, sprayed in-house, and finished to exacting standards.</p>
         <p>We work closely with homeowners, architects, and designers across Wicklow and surrounding areas, guiding each project from concept through to installation. Our process is collaborative, precise, and entirely tailored. The result is a space that feels uniquely yours — both beautifully functional and made to last.</p>
+      </div>
+    </div>
+  </section>
+  <section class="media-left">
+    <h1 class="media-left__heading">From Concept to Completion</h1>
+    <div class="media-left__wrapper">
+      <div class="media-left__image">
+        <img src="images/hero/wine-rack.jpg" alt="Bespoke joinery project" />
+      </div>
+      <div class="media-left__content">
+        <p>At Cove Bespoke, we offer a full-service approach to interior joinery — from first concepts to final installation. Whether it's a statement kitchen, a walk-in wardrobe, or a custom media wall, every piece is made to order and built around your space, your needs, and your aesthetic. We manage every stage in-house, ensuring craftsmanship, consistency, and control from start to finish.</p>
+        <h2>Design – Tailored from the Start</h2>
+        <p>We begin with a detailed design consultation to understand how you live and what you love. Our team creates precise digital plans and photorealistic visuals so you can explore every detail before we begin.</p>
+        <h2>Manufacture – Built by Hand in Wicklow</h2>
+        <p>Every component is handmade in our Wicklow workshop using time-honoured techniques and modern tooling. Our cabinetmakers build everything from scratch using carefully selected materials — nothing is off-the-shelf or prefabricated.</p>
+        <h2>Finishing – Sprayed and Detailed In-House</h2>
+        <p>With dedicated spray facilities on-site, we control every aspect of the finish — from colour to sheen to durability. This ensures a flawless surface across all panels and components.</p>
+        <h2>Installation – Seamless and Considered</h2>
+        <p>Our experienced fitters ensure each project is delivered with care and precision. Every join, alignment, and adjustment is managed on site to ensure a perfect fit and lasting performance.</p>
+        <p>Every Cove Bespoke project includes:</p>
+        <ul class="media-left__list">
+          <li>Fully bespoke design service with 3D visuals</li>
+          <li>Made-to-order furniture and joinery</li>
+          <li>In-house spraying for premium painted finishes</li>
+          <li>Expert installation by our trusted team</li>
+          <li>Full project management throughout</li>
+        </ul>
       </div>
     </div>
   </section>

--- a/sections/media-left/style.css
+++ b/sections/media-left/style.css
@@ -142,3 +142,34 @@
   .media-left__image   { order: 2; }   /* show after content */
   .media-left__content { order: 1; }   /* show before image  */
 }
+
+/* === Bullet list styling ================================ */
+.media-left__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.media-left__list li {
+  position: relative;
+  padding-left: 2.25rem;
+  margin-bottom: 1rem;
+  line-height: 1.6;
+}
+
+.media-left__list li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.45em;
+  width: 0.75rem;
+  height: 0.75rem;
+  border: 2px solid var(--color-blue);
+  border-radius: 50%;
+  box-sizing: border-box;
+}
+
+.media-left__list li span {
+  font-weight: 700;
+  margin-right: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- add "From Concept to Completion" media-left block after intro banner
- style media-left bullets with custom outlined dots

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68920f70e55c83308763d95fb6edefe7