### PR TITLE
Align section headings

### DIFF
--- a/sections/documentations/style.css
+++ b/sections/documentations/style.css
@@ -25,8 +25,10 @@
 }
 
 .error-wrapper h1 {
-  font-family: var(--font-heading);
-  font-size: clamp(48px, 12vw, 120px);
+  font-family: var(--font-serif);
+  font-size: var(--fs-1000);
+  font-weight: 400;
+  line-height: var(--lh-heading);
   margin: 0 0 20px;
   color: var(--color-blue);
 }

--- a/sections/hero/style.css
+++ b/sections/hero/style.css
@@ -41,8 +41,9 @@
 
 .hero-content h1 {
   font-family: var(--font-serif);
-  font-size: clamp(2rem, 5vw, 4rem);
-  line-height: 1.1;
+  font-size: var(--fs-1000);
+  font-weight: 400;
+  line-height: var(--lh-heading);
   margin-bottom: var(--space-4);
   color: #fff;
   text-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);

--- a/sections/intro-banner/style.css
+++ b/sections/intro-banner/style.css
@@ -15,7 +15,9 @@
 .intro-banner__content h1 {
   margin-top: 5vw;
   margin-bottom: 50px;
-  font-size: clamp(36px, 9vw, 100px);
+  font-family: var(--font-serif);
+  font-size: var(--fs-1000);
+  font-weight: 400;
   text-align: center;
 }
 

--- a/sections/media-left/style.css
+++ b/sections/media-left/style.css
@@ -10,9 +10,9 @@
 .media-left__heading {
   font-family: var(--font-serif);
   font-weight: 400;
+  font-size: var(--fs-1000);
   color: var(--color-blue);
   text-transform: uppercase;
-  font-size: clamp(28px, 8vw, 48px);
   margin: 2rem 1.5rem;
 }
 
@@ -68,7 +68,7 @@
 /* ---------- Tablet (768 – 1023 px) ---------- */
 @media (min-width: 768px) and (max-width: 1023px) {
   .media-left__heading {
-    font-size: clamp(32px, 6vw, 56px);
+    font-size: var(--fs-1000);
     margin: 4rem 2rem 2.5rem;
   }
 
@@ -119,7 +119,7 @@
   }
 
   .media-left__heading {
-    font-size: clamp(40px, 4vw, 64px);
+    font-size: var(--fs-1000);
     margin: 6rem 0 3rem;
     text-align: center;
   }


### PR DESCRIPTION
## Summary
- Normalize hero section heading styling with global font, size, and weight tokens
- Unify intro banner and media-left section `<h1>` styles to use shared typography variables
- Fix 404 error page heading to rely on base heading scale

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689218b5ab04833095ebf13d43838d01