### PR TITLE
Define heading and body font variables

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -25,6 +25,8 @@
   /* Fonts */
   --font-serif: 'DM Serif Display', serif;
   --font-sans:  'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-heading: var(--font-serif);
+  --font-body:    var(--font-sans);
 
   /* Fluid type‑scale (mobile‑first → desktop) */
   --fs-400:  clamp(1rem, 0.95rem + 0.25vw, 1.125rem); /* body */


### PR DESCRIPTION
## Summary
- ensure sections like media scroller and headings use standard font by mapping `--font-heading` and `--font-body` to existing serif and sans families

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68922142511c83309b18d3a13c8a5c05