### PR TITLE
feat: color section headings with accent

### DIFF
--- a/sections/documentations/style.css
+++ b/sections/documentations/style.css
@@ -28,7 +28,7 @@
   font-family: var(--font-heading);
   font-size: clamp(48px, 12vw, 120px);
   margin: 0 0 20px;
-  color: var(--color-blue);
+  color: var(--c-accent);
 }
 
 .error-message {

--- a/sections/page-title/style.css
+++ b/sections/page-title/style.css
@@ -11,7 +11,7 @@
   font-family: var(--font-heading);
   font-size: clamp(32px, 8vw, 48px);
   font-weight: 500;
-  color: var(--color-blue);
+  color: var(--c-accent);
   margin-bottom: 16px;
 }
 

--- a/style/base.css
+++ b/style/base.css
@@ -96,7 +96,7 @@ h1,h2,h3,h4,h5,h6{
   margin:0 0 var(--space-4) 0;
   color:var(--c-text);
 }
-h1{font-size:var(--fs-1000);letter-spacing:-0.02em;}
+h1{color:var(--c-accent);font-size:var(--fs-1000);letter-spacing:-0.02em;}
 h2{font-size:var(--fs-900);}
 h3{font-size:var(--fs-800);}
 h4{font-size:var(--fs-700);}


### PR DESCRIPTION
## Summary
- style H1 headings with accent green
- ensure page-title and error page headings use accent color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892248ed7bc8330b123346a66ea4667