### PR TITLE
feat: align section headers with accent colour

### DIFF
--- a/style/variables.css
+++ b/style/variables.css
@@ -1,1 +1,14 @@
+/*------------------------------------------------------------
+  Global colour variables
+  --------------------------------------------------------- */
+:root {
+  /* Section accent and text colours */
+  --color-blue: var(--c-accent); /* deep green accent */
+  --color-text: var(--c-text);
+
+  /* Utility colours */
+  --color-white: var(--c-surface);
+  --color-black: var(--c-text);
+}
+
 /* Ready */


### PR DESCRIPTION
## Summary
- define shared colour variables
- map section headings to use site green accent

## Testing
- `npm test` (fails: ENOENT no package.json)


------
https://chatgpt.com/codex/tasks/task_e_68926df4dd58833090d2b054a0f51e84