### PR TITLE
fix rotating gallery tabs and background

### DIFF
--- a/sections/rotating-gallery/style.css
+++ b/sections/rotating-gallery/style.css
@@ -1,6 +1,6 @@
 /* ─── rotating-gallery (inherits Installation-Process layout) ───────────── */
 .rotating-gallery-process {
-  background: #fff;
+  background: var(--c-bg);
   text-align: center;
   position: relative;
 }
@@ -150,6 +150,8 @@
 .tabs-swiper {
   overflow: hidden;
   padding: 0 16px;
+  display: block;
+  width: 100%;
 }
 
 .tabs-swiper .swiper-wrapper {


### PR DESCRIPTION
## Summary
- ensure rotating gallery pills are visible by letting the tabs container span full width
- align rotating gallery section with site styling via the global background color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68932e49da208330a2416a4e0cb03c62