### PR TITLE
Fix pill carousel collapse for fewer slides

### DIFF
--- a/sections/rotating-gallery/script.js
+++ b/sections/rotating-gallery/script.js
@@ -73,14 +73,25 @@
 
   function buildPills(center) {
     trackEl.innerHTML = '';
-    const visible = 20;
-    const half    = Math.floor(visible / 2);
-    for (let off = -half; off <= half; off++) {
-      const i = (center + off + total) % total;
-      const clone = originals[i].cloneNode(true);
-      addTabClick(clone.querySelector('.tab'));
-      trackEl.appendChild(clone);
+    const visible = Math.min(total, 20);
+
+    if (visible === total) {
+      originals.forEach(slide => {
+        const clone = slide.cloneNode(true);
+        addTabClick(clone.querySelector('.tab'));
+        trackEl.appendChild(clone);
+      });
+    } else {
+      const half = Math.floor(visible / 2);
+      for (let off = -half; off <= half; off++) {
+        let i = (center + off) % total;
+        if (i < 0) i += total;
+        const clone = originals[i].cloneNode(true);
+        addTabClick(clone.querySelector('.tab'));
+        trackEl.appendChild(clone);
+      }
     }
+
     updateScale();
   }
 


### PR DESCRIPTION
## Summary
- prevent rotating gallery pills from collapsing when fewer than 10 items
- normalise pill index math and show original slides when below threshold

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68936192e0608330bf369ac3d54810f2