### PR TITLE
Align mobile logo and menu with shrinking header

### DIFF
--- a/header/style.css
+++ b/header/style.css
@@ -42,6 +42,7 @@
   height: 60px;
   width: auto;
   display: block;
+  transition: height 0.3s ease;
 }
 
 /* -------- Nav -------- */
@@ -88,6 +89,7 @@
   border: none;
   position: relative;
   z-index: 1400;
+  transition: width 0.3s ease, height 0.3s ease;
 }
 .hamburger span {
   display: block;
@@ -148,5 +150,13 @@ body.no-scroll {
   }
   .hamburger {
     display: block;
+  }
+
+  .site-header.is-elevated .header-logo img {
+    height: 40px;
+  }
+  .site-header.is-elevated .hamburger {
+    --line-w: 20px;
+    --gap: 4px;
   }
 }


### PR DESCRIPTION
## Summary
- allow header logo and hamburger to resize when the sticky header shrinks on scroll
- add CSS transitions for smooth logo and menu scaling

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689374a8877c8330b6c6b6cc5a54d844