### PR TITLE
Fix mobile header flicker and shrink

### DIFF
--- a/header/header.html
+++ b/header/header.html
@@ -62,7 +62,7 @@
         const header = document.querySelector('[data-js="site-header"]');
         const burger = document.querySelector('[data-js="hamburger"]');
         const mobileNav = document.querySelector('[data-js="mobile-nav"]');
-        let lastScroll = 0;
+        let isElevated = false;
 
         // Toggle drawer
         burger.addEventListener('click', () => {
@@ -96,8 +96,13 @@
         // Scroll elevation effect
         window.addEventListener('scroll', () => {
           const curr = window.scrollY;
-          header.classList.toggle('is-elevated', curr > 10);
-          lastScroll = curr;
+          if (!isElevated && curr > 10) {
+            header.classList.add('is-elevated');
+            isElevated = true;
+          } else if (isElevated && curr <= 10) {
+            header.classList.remove('is-elevated');
+            isElevated = false;
+          }
         });
       })();
     </script>

--- a/header/style.css
+++ b/header/style.css
@@ -11,7 +11,7 @@
   z-index: 1400;
   background-color: var(--c-bg);
   padding-block: 0.75rem; /* 12px */
-  transition: box-shadow 0.3s ease;
+  transition: box-shadow 0.3s ease, padding-block 0.3s ease;
 }
 .site-header.is-elevated {
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.04);
@@ -152,6 +152,9 @@ body.no-scroll {
     display: block;
   }
 
+  .site-header.is-elevated {
+    padding-block: 0.25rem;
+  }
   .site-header.is-elevated .header-logo img {
     height: 40px;
   }


### PR DESCRIPTION
## Summary
- prevent flicker by only toggling `is-elevated` when crossing threshold
- ensure mobile header shrinks smoothly with reduced padding

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893773c0e048330899bda0dc7ff72ca