### PR TITLE
Add projects card grid page

### DIFF
--- a/header/header.html
+++ b/header/header.html
@@ -30,7 +30,7 @@
         <!-- Primary navigation (desktop) -->
         <nav class="primary-nav" aria-label="Primary Navigation">
           <a href="index.html">Home</a>
-          <a href="portfolio.html">Portfolio</a>
+          <a href="portfolio.html">Projects</a>
           <a href="services.html">Services</a>
           <a href="journal.html">Journal</a>
           <a href="about.html">About</a>
@@ -49,7 +49,7 @@
     <!-- Mobile nav drawer -->
     <nav id="mobile-drawer" class="mobile-nav" aria-label="Mobile Navigation" data-js="mobile-nav">
       <a href="index.html">Home</a>
-      <a href="portfolio.html">Portfolio</a>
+      <a href="portfolio.html">Projects</a>
       <a href="services.html">Services</a>
       <a href="journal.html">Journal</a>
       <a href="about.html">About</a>

--- a/portfolio.html
+++ b/portfolio.html
@@ -1,4 +1,137 @@
-<!-- Ready -->
-markdown
-Copy
-Edit
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Projects – Cove Bespoke</title>
+  <link rel="stylesheet" href="style/variables.css">
+  <link rel="stylesheet" href="style/base.css">
+  <link rel="stylesheet" href="style/layout.css">
+  <link rel="stylesheet" href="style/sections.css">
+  <link rel="stylesheet" href="style/components.css">
+  <link rel="stylesheet" href="style/buttons.css">
+  <link rel="stylesheet" href="style/forms.css">
+  <link rel="stylesheet" href="sections/page-title/style.css">
+  <link rel="stylesheet" href="sections/card-grid/style.css">
+</head>
+<body>
+  <div id="header-placeholder"></div>
+
+  <section class="page-title">
+    <h1 class="page-title__heading">Projects</h1>
+  </section>
+
+  <section class="card-grid">
+    <div class="card">
+      <figure class="card__img">
+        <img src="images/projects/classic-shaker-kitchen/cover.JPG" alt="Classic Shaker Kitchen" loading="lazy">
+      </figure>
+      <h3 class="card__title">Classic Shaker Kitchen</h3>
+      <p class="card__meta">Kitchen · Wicklow · 2024</p>
+    </div>
+    <div class="card">
+      <figure class="card__img">
+        <img src="images/projects/dark-handleless-kitchen/cover.JPG" alt="Dark Handleless Kitchen" loading="lazy">
+      </figure>
+      <h3 class="card__title">Dark Handleless Kitchen</h3>
+      <p class="card__meta">Kitchen · Dublin · 2024</p>
+    </div>
+    <div class="card">
+      <figure class="card__img">
+        <img src="images/projects/dark-porcelain-kitchen/cover.JPG" alt="Dark Porcelain Kitchen" loading="lazy">
+      </figure>
+      <h3 class="card__title">Dark Porcelain Kitchen</h3>
+      <p class="card__meta">Kitchen · Wicklow · 2024</p>
+    </div>
+    <div class="card">
+      <figure class="card__img">
+        <img src="images/projects/dark-shaker-wardrobe/cover.JPG" alt="Dark Shaker Wardrobe" loading="lazy">
+      </figure>
+      <h3 class="card__title">Dark Shaker Wardrobe</h3>
+      <p class="card__meta">Wardrobe · Dublin · 2024</p>
+    </div>
+    <div class="card">
+      <figure class="card__img">
+        <img src="images/projects/gloss-white-kitchen/cover.JPG" alt="Gloss White Kitchen" loading="lazy">
+      </figure>
+      <h3 class="card__title">Gloss White Kitchen</h3>
+      <p class="card__meta">Kitchen · Wicklow · 2024</p>
+    </div>
+    <div class="card">
+      <figure class="card__img">
+        <img src="images/projects/light-grey-handleless-kitchen/cover.JPG" alt="Light Grey Handleless Kitchen" loading="lazy">
+      </figure>
+      <h3 class="card__title">Light Grey Handleless Kitchen</h3>
+      <p class="card__meta">Kitchen · Dublin · 2024</p>
+    </div>
+    <div class="card">
+      <figure class="card__img">
+        <img src="images/projects/porcelain-kitchen/cover.PNG" alt="Porcelain Kitchen" loading="lazy">
+      </figure>
+      <h3 class="card__title">Porcelain Kitchen</h3>
+      <p class="card__meta">Kitchen · Wicklow · 2024</p>
+    </div>
+    <div class="card">
+      <figure class="card__img">
+        <img src="images/projects/home-bar-cabinetry/cover.jpg" alt="Home Bar Cabinetry" loading="lazy">
+      </figure>
+      <h3 class="card__title">Home Bar Cabinetry</h3>
+      <p class="card__meta">Home Bar · Dublin · 2024</p>
+    </div>
+    <div class="card">
+      <figure class="card__img">
+        <img src="images/projects/media-wall-display-unit/cover.JPG" alt="Media Wall Display Unit" loading="lazy">
+      </figure>
+      <h3 class="card__title">Media Wall Display Unit</h3>
+      <p class="card__meta">Media Unit · Wicklow · 2024</p>
+    </div>
+    <div class="card">
+      <figure class="card__img">
+        <img src="images/projects/walnut-winerack/cover.jpg" alt="Walnut Wine Rack" loading="lazy">
+      </figure>
+      <h3 class="card__title">Walnut Wine Rack</h3>
+      <p class="card__meta">Wine Storage · Dublin · 2024</p>
+    </div>
+  </section>
+
+  <div id="footer-placeholder"></div>
+
+  <script src="sections/card-grid/script.js"></script>
+  <script>
+    function loadPartial(url, placeholderId) {
+      fetch(url)
+        .then(res => res.text())
+        .then(html => {
+          const parser = new DOMParser();
+          const doc = parser.parseFromString(html, 'text/html');
+          const fragment = document.createDocumentFragment();
+          doc.body.childNodes.forEach(node => fragment.appendChild(node.cloneNode(true)));
+          const placeholder = document.getElementById(placeholderId);
+          placeholder.replaceWith(fragment);
+
+          doc.head
+            .querySelectorAll('link[rel="stylesheet"], style')
+            .forEach(el => {
+              const clone = el.cloneNode(true);
+              if (el.tagName.toLowerCase() === 'link') {
+                const exists = Array.from(document.head.querySelectorAll('link')).some(l => l.href === clone.href);
+                if (!exists) document.head.appendChild(clone);
+              } else {
+                document.head.appendChild(clone);
+              }
+            });
+
+          doc.querySelectorAll('script').forEach(src => {
+            const s = document.createElement('script');
+            if (src.src) { s.src = src.src; } else { s.textContent = src.textContent; }
+            document.body.appendChild(s);
+          });
+        })
+        .catch(err => console.error('Failed to load', url, err));
+    }
+    loadPartial('header/header.html', 'header-placeholder');
+    loadPartial('footer/footer.html', 'footer-placeholder');
+  </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- replace placeholder portfolio page with full Projects grid
- load project cover images and metadata in responsive card layout
- rename header navigation link to Projects

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894a5e74c9c8330b744c1f93037d5d5