### PR TITLE
Enhance portfolio page intro and header link

### DIFF
--- a/header/header.html
+++ b/header/header.html
@@ -30,7 +30,7 @@
         <!-- Primary navigation (desktop) -->
         <nav class="primary-nav" aria-label="Primary Navigation">
           <a href="index.html">Home</a>
-          <a href="portfolio.html">Projects</a>
+          <a href="portfolio.html">Portfolio</a>
           <a href="services.html">Services</a>
           <a href="journal.html">Journal</a>
           <a href="about.html">About</a>
@@ -49,7 +49,7 @@
     <!-- Mobile nav drawer -->
     <nav id="mobile-drawer" class="mobile-nav" aria-label="Mobile Navigation" data-js="mobile-nav">
       <a href="index.html">Home</a>
-      <a href="portfolio.html">Projects</a>
+      <a href="portfolio.html">Portfolio</a>
       <a href="services.html">Services</a>
       <a href="journal.html">Journal</a>
       <a href="about.html">About</a>

--- a/portfolio.html
+++ b/portfolio.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Projects – Cove Bespoke</title>
+  <title>Portfolio – Cove Bespoke</title>
   <link rel="stylesheet" href="style/variables.css">
   <link rel="stylesheet" href="style/base.css">
   <link rel="stylesheet" href="style/layout.css">
@@ -17,8 +17,20 @@
 <body>
   <div id="header-placeholder"></div>
 
-  <section class="page-title">
-    <h1 class="page-title__heading">Projects</h1>
+  <section class="page-title fade-in" aria-labelledby="page-h1">
+    <h1 id="page-h1" class="page-title__heading">Portfolio</h1>
+
+    <div class="page-title-text">
+      <!-- Sub-title -->
+      <p class="sub">
+        Bespoke interiors, made to last.
+      </p>
+
+      <!-- Intro -->
+      <p class="intro">
+        At Cove Bespoke, every project is a reflection of our design-led approach, meticulous craftsmanship, and commitment to lasting quality. From contemporary kitchens to tailored wardrobes, wine rooms, and more, each space is made to order and thoughtfully crafted around our clients' needs. Explore a selection of our recent work — a glimpse into spaces that balance function, beauty, and individuality.
+      </p>
+    </div>
   </section>
 
   <section class="card-grid">


### PR DESCRIPTION
## Summary
- Rename navigation link from Projects to Portfolio
- Introduce Portfolio page with page title, subheading, and intro paragraph

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894aa66d9e48330ad91f65bb9b04908