### PR TITLE
Add page title section to services page

### DIFF
--- a/services.html
+++ b/services.html
@@ -1,4 +1,71 @@
-<!-- Ready -->
-markdown
-Copy
-Edit
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Services – Cove Bespoke</title>
+  <link rel="stylesheet" href="style/variables.css">
+  <link rel="stylesheet" href="style/base.css">
+  <link rel="stylesheet" href="style/layout.css">
+  <link rel="stylesheet" href="style/sections.css">
+  <link rel="stylesheet" href="style/components.css">
+  <link rel="stylesheet" href="style/buttons.css">
+  <link rel="stylesheet" href="style/forms.css">
+  <link rel="stylesheet" href="sections/page-title/style.css">
+</head>
+<body>
+  <div id="header-placeholder"></div>
+
+  <section class="page-title fade-in" aria-labelledby="page-h1">
+    <h1 id="page-h1" class="page-title__heading">Services</h1>
+
+    <div class="page-title-text">
+      <p class="sub">
+        A complete bespoke service from first sketch to final fit.
+      </p>
+
+      <p class="intro">
+        Cove Bespoke offers a full start-to-finish interiors service built around quality, clarity, and care. From precise on-site measurements and photorealistic design visuals to handmade cabinetry, in-house spraying, and expert installation, everything is managed under one roof. There’s no showroom, no sales team, and no handovers — just a dedicated craftsperson guiding your project from the first conversation to the final detail.
+      </p>
+    </div>
+  </section>
+
+  <div id="footer-placeholder"></div>
+
+  <script>
+    function loadPartial(url, placeholderId) {
+      fetch(url)
+        .then(res => res.text())
+        .then(html => {
+          const parser = new DOMParser();
+          const doc = parser.parseFromString(html, 'text/html');
+          const fragment = document.createDocumentFragment();
+          doc.body.childNodes.forEach(node => fragment.appendChild(node.cloneNode(true)));
+          const placeholder = document.getElementById(placeholderId);
+          placeholder.replaceWith(fragment);
+
+          doc.head
+            .querySelectorAll('link[rel="stylesheet"], style')
+            .forEach(el => {
+              const clone = el.cloneNode(true);
+              if (el.tagName.toLowerCase() === 'link') {
+                const exists = Array.from(document.head.querySelectorAll('link')).some(l => l.href === clone.href);
+                if (!exists) document.head.appendChild(clone);
+              } else {
+                document.head.appendChild(clone);
+              }
+            });
+
+          doc.querySelectorAll('script').forEach(src => {
+            const s = document.createElement('script');
+            if (src.src) { s.src = src.src; } else { s.textContent = src.textContent; }
+            document.body.appendChild(s);
+          });
+        })
+        .catch(err => console.error('Failed to load', url, err));
+    }
+    loadPartial('header/header.html', 'header-placeholder');
+    loadPartial('footer/footer.html', 'footer-placeholder');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold services page with page-title section mirroring projects layout
- include bespoke subheading and intro paragraph describing end-to-end service

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894bbf1952c83309db8d79be832ce80