### PR TITLE
Link services images to relevant project photos

### DIFF
--- a/services.html
+++ b/services.html
@@ -37,7 +37,7 @@
   <section class="section media-left" aria-labelledby="design-consultation-heading">
     <div class="media-left__wrapper">
       <figure class="media-left__image">
-        <img src="images/services/consultation.jpg" alt="Client consultation for kitchen design">
+        <img src="images/projects/light-grey-handleless-kitchen/cover.JPG" alt="Light grey handleless kitchen design example">
       </figure>
       <div class="media-left__content">
         <h2 id="design-consultation-heading">Consultation & Design</h2>
@@ -67,7 +67,7 @@
         </p>
       </div>
       <figure class="media-right__image">
-        <img src="images/services/cad-visual.jpg" alt="3D rendered kitchen design using CAD software">
+        <img src="images/CAD_Visual.jpg" alt="3D rendered kitchen design using CAD software">
       </figure>
     </div>
   </section>
@@ -77,7 +77,7 @@
   <section class="section media-left" aria-labelledby="craftsmanship-heading">
     <div class="media-left__wrapper">
       <figure class="media-left__image">
-        <img src="images/services/cabinetmaking.jpg" alt="Bespoke furniture being handmade in workshop">
+        <img src="images/projects/walnut-winerack/2.JPG" alt="Walnut wine rack cabinetry during build">
       </figure>
       <div class="media-left__content">
         <h2 id="craftsmanship-heading">Handmade in Wicklow</h2>
@@ -107,7 +107,7 @@
         </p>
       </div>
       <figure class="media-right__image">
-        <img src="images/services/spray.jpg" alt="In-house spray booth for bespoke joinery finishes">
+        <img src="images/projects/gloss-white-kitchen/cover.JPG" alt="Gloss white kitchen cabinets with smooth sprayed finish">
       </figure>
     </div>
   </section>
@@ -117,7 +117,7 @@
   <section class="section media-left" aria-labelledby="installation-heading">
     <div class="media-left__wrapper">
       <figure class="media-left__image">
-        <img src="images/services/installation.jpg" alt="Final kitchen being installed in client home">
+        <img src="images/projects/dark-handleless-kitchen/3.JPG" alt="Dark handleless kitchen being installed">
       </figure>
       <div class="media-left__content">
         <h2 id="installation-heading">Delivery & Installation</h2>
@@ -147,7 +147,7 @@
         </p>
       </div>
       <figure class="media-right__image">
-        <img src="images/services/personal-service.jpg" alt="Craftsman working on bespoke furniture project">
+        <img src="images/projects/media-wall-display-unit/1.JPG" alt="Custom media wall display unit installation">
       </figure>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Replace service section images with photos from project gallery
- Show CAD_Visual rendering for Photorealistic CAD Visuals

## Testing
- `npx -y html-validate services.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html-validate)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c0720a1c83309899278d1a4b88ef