### PR TITLE
Swap media orientation on services page

### DIFF
--- a/services.html
+++ b/services.html
@@ -20,23 +20,16 @@
 
   <section class="page-title fade-in" aria-labelledby="page-h1">
     <h1 id="page-h1" class="page-title__heading">Services</h1>
-
-    <div class="page-title-text">
-      <p class="sub">
-        A complete bespoke service from first sketch to final fit.
-      </p>
-
-      <p class="intro">
-        Cove Bespoke offers a full start-to-finish interiors service built around quality, clarity, and care. From precise on-site measurements and photorealistic design visuals to handmade cabinetry, in-house spraying, and expert installation, everything is managed under one roof. There’s no showroom, no sales team, and no handovers — just a dedicated craftsperson guiding your project from the first conversation to the final detail.
-      </p>
-    </div>
   </section>
 
 
-  <!-- 1. Consultation & Design media-right -->
-  <section class="section media-right" aria-labelledby="design-consultation-heading">
-    <div class="media-right__wrapper">
-      <div class="media-right__content">
+  <!-- 1. Consultation & Design media-left -->
+  <section class="section media-left" aria-labelledby="design-consultation-heading">
+    <div class="media-left__wrapper">
+      <figure class="media-left__image">
+        <img src="images/projects/light-grey-handleless-kitchen/cover.JPG" alt="Light grey handleless kitchen design example">
+      </figure>
+      <div class="media-left__content">
         <h2 id="design-consultation-heading">Consultation & Design</h2>
         <p class="subheading">It starts with how you live.</p>
         <p class="intro">
@@ -46,20 +39,14 @@
           This process is collaborative, practical, and entirely focused on how you use your home. It lays the foundation for truly bespoke interiors, designed with clarity, not guesswork.
         </p>
       </div>
-      <figure class="media-right__image">
-        <img src="images/projects/light-grey-handleless-kitchen/cover.JPG" alt="Light grey handleless kitchen design example">
-      </figure>
     </div>
   </section>
 
 
-  <!-- 2. Photorealistic CAD Visuals media-left -->
-  <section class="media-left" aria-labelledby="cad-visuals-heading">
-    <div class="media-left__wrapper">
-      <figure class="media-left__image">
-        <img src="images/CAD_Visual.jpg" alt="3D rendered kitchen design using CAD software">
-      </figure>
-      <div class="media-left__content">
+  <!-- 2. Photorealistic CAD Visuals media-right -->
+  <section class="media-right" aria-labelledby="cad-visuals-heading">
+    <div class="media-right__wrapper">
+      <div class="media-right__content">
         <h2 id="cad-visuals-heading">Photorealistic CAD Visuals</h2>
         <p class="subheading">See it before it's made.</p>
         <p class="intro">
@@ -69,88 +56,91 @@
           Whether it’s a full kitchen or a single wardrobe, every project is designed digitally for precision and visual clarity.
         </p>
       </div>
-    </div>
-  </section>
-
-
-  <!-- 3. Handmade Craftsmanship media-right -->
-  <section class="section media-right" aria-labelledby="craftsmanship-heading">
-    <div class="media-right__wrapper">
-      <div class="media-right__content">
-        <h2 id="craftsmanship-heading">Handmade in Wicklow</h2>
-        <p class="subheading">Crafted from raw materials, not catalogues.</p>
-        <p class="intro">
-          Every piece we build is made to order in our workshop. We never use flat pack shortcuts or generic carcasses. We work from raw boards, shaping every component by hand to fit your project precisely.
-        </p>
-        <p class="intro">
-          This means stronger structures, finer details, and a level of quality that simply cannot be matched by mass production.
-        </p>
-      </div>
       <figure class="media-right__image">
-        <img src="images/projects/walnut-winerack/2.JPG" alt="Walnut wine rack cabinetry during build">
+        <img src="images/CAD_Visual.jpg" alt="3D rendered kitchen design using CAD software">
       </figure>
     </div>
   </section>
 
 
-  <!-- 4. In-House Spray Finishing media-left -->
-  <section class="media-left" aria-labelledby="spray-finishing-heading">
-    <div class="media-left__wrapper">
-      <figure class="media-left__image">
-        <img src="images/projects/gloss-white-kitchen/cover.JPG" alt="Gloss white kitchen cabinets with smooth sprayed finish">
-      </figure>
-      <div class="media-left__content">
-        <h2 id="spray-finishing-heading">In-House Spray Finishing</h2>
-        <p class="subheading">Your colour, your finish, controlled in house.</p>
-        <p class="intro">
-          We operate our own dedicated spray room, giving us full control over the colour, tone, sheen, and texture of every painted finish. From soft matte heritage shades to durable high gloss lacquers, each finish is smooth, even, and long lasting.
-        </p>
-        <p class="intro">
-          This in house capability ensures consistency and quality every time.
-        </p>
+    <!-- 3. Handmade Craftsmanship media-left -->
+    <section class="section media-left" aria-labelledby="craftsmanship-heading">
+      <div class="media-left__wrapper">
+        <figure class="media-left__image">
+          <img src="images/projects/walnut-winerack/2.JPG" alt="Walnut wine rack cabinetry during build">
+        </figure>
+        <div class="media-left__content">
+          <h2 id="craftsmanship-heading">Handmade in Wicklow</h2>
+          <p class="subheading">Crafted from raw materials, not catalogues.</p>
+          <p class="intro">
+            Every piece we build is made to order in our workshop. We never use flat pack shortcuts or generic carcasses. We work from raw boards, shaping every component by hand to fit your project precisely.
+          </p>
+          <p class="intro">
+            This means stronger structures, finer details, and a level of quality that simply cannot be matched by mass production.
+          </p>
+        </div>
       </div>
-    </div>
-  </section>
+    </section>
 
 
-  <!-- 5. Delivery & Installation media-right -->
-  <section class="section media-right" aria-labelledby="installation-heading">
-    <div class="media-right__wrapper">
-      <div class="media-right__content">
-        <h2 id="installation-heading">Delivery & Installation</h2>
-        <p class="subheading">Fitted with care, not just speed.</p>
-        <p class="intro">
-          Once built and finished, every piece is personally delivered and installed with precision. We never subcontract fitters. Your project is handled by the same hands that designed and made it.
-        </p>
-        <p class="intro">
-          From alignments to soft close fittings, we make sure every element works exactly as intended. No shortcuts, no guesswork.
-        </p>
+    <!-- 4. In-House Spray Finishing media-right -->
+    <section class="media-right" aria-labelledby="spray-finishing-heading">
+      <div class="media-right__wrapper">
+        <div class="media-right__content">
+          <h2 id="spray-finishing-heading">In-House Spray Finishing</h2>
+          <p class="subheading">Your colour, your finish, controlled in house.</p>
+          <p class="intro">
+            We operate our own dedicated spray room, giving us full control over the colour, tone, sheen, and texture of every painted finish. From soft matte heritage shades to durable high gloss lacquers, each finish is smooth, even, and long lasting.
+          </p>
+          <p class="intro">
+            This in house capability ensures consistency and quality every time.
+          </p>
+        </div>
+        <figure class="media-right__image">
+          <img src="images/projects/gloss-white-kitchen/cover.JPG" alt="Gloss white kitchen cabinets with smooth sprayed finish">
+        </figure>
       </div>
-      <figure class="media-right__image">
-        <img src="images/projects/dark-handleless-kitchen/3.JPG" alt="Dark handleless kitchen being installed">
-      </figure>
-    </div>
-  </section>
+    </section>
 
 
-  <!-- 6. Complete Bespoke Interiors media-left -->
-  <section class="media-left" aria-labelledby="complete-service-heading">
-    <div class="media-left__wrapper">
-      <figure class="media-left__image">
-        <img src="images/projects/media-wall-display-unit/1.JPG" alt="Custom media wall display unit installation">
-      </figure>
-      <div class="media-left__content">
-        <h2 id="complete-service-heading">The Full Bespoke Service</h2>
-        <p class="subheading">One craftsman. One point of contact.</p>
-        <p class="intro">
-          Cove Bespoke is not a showroom, a sales team, or a factory line. It is a focused personal service, from consultation to design, build, and installation, led by a single maker who oversees every detail.
-        </p>
-        <p class="intro">
-          Whether it is a kitchen, wardrobe, wine room, or fitted bar, you deal directly with the person designing and crafting your space. The result is calm communication, clear expectations, and beautiful results.
-        </p>
+    <!-- 5. Delivery & Installation media-left -->
+    <section class="section media-left" aria-labelledby="installation-heading">
+      <div class="media-left__wrapper">
+        <figure class="media-left__image">
+          <img src="images/projects/dark-handleless-kitchen/3.JPG" alt="Dark handleless kitchen being installed">
+        </figure>
+        <div class="media-left__content">
+          <h2 id="installation-heading">Delivery & Installation</h2>
+          <p class="subheading">Fitted with care, not just speed.</p>
+          <p class="intro">
+            Once built and finished, every piece is personally delivered and installed with precision. We never subcontract fitters. Your project is handled by the same hands that designed and made it.
+          </p>
+          <p class="intro">
+            From alignments to soft close fittings, we make sure every element works exactly as intended. No shortcuts, no guesswork.
+          </p>
+        </div>
       </div>
-    </div>
-  </section>
+    </section>
+
+
+    <!-- 6. Complete Bespoke Interiors media-right -->
+    <section class="media-right" aria-labelledby="complete-service-heading">
+      <div class="media-right__wrapper">
+        <div class="media-right__content">
+          <h2 id="complete-service-heading">The Full Bespoke Service</h2>
+          <p class="subheading">One craftsman. One point of contact.</p>
+          <p class="intro">
+            Cove Bespoke is not a showroom, a sales team, or a factory line. It is a focused personal service, from consultation to design, build, and installation, led by a single maker who oversees every detail.
+          </p>
+          <p class="intro">
+            Whether it is a kitchen, wardrobe, wine room, or fitted bar, you deal directly with the person designing and crafting your space. The result is calm communication, clear expectations, and beautiful results.
+          </p>
+        </div>
+        <figure class="media-right__image">
+          <img src="images/projects/media-wall-display-unit/1.JPG" alt="Custom media wall display unit installation">
+        </figure>
+      </div>
+    </section>
 
 
   <!-- Featured Projects media-scroller -->


### PR DESCRIPTION
## Summary
- Remove subtitle and intro paragraph from Services page header
- Flip all Services media sections so images and text swap sides

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c61546b0833081bfba03393f423c