### PR TITLE
Align trade page intro banner typography

### DIFF
--- a/trade.html
+++ b/trade.html
@@ -33,8 +33,8 @@
     <div class="intro-banner__content">
       <h1>For Builders, Designers &amp; Architects</h1>
       <div class="intro-banner__text-block">
-        <p class="text-muted">A reliable partner for precision joinery and high end residential projects.</p>
-        <p>
+        <p class="subheading">A reliable partner for precision joinery and high end residential projects.</p>
+        <p class="intro">
           Cove Bespoke works with trade professionals who need a focused workshop and clear communication from the first briefing to final installation. There is no showroom and no sales team. You work directly with the maker who designs, builds, finishes, and installs.
         </p>
       </div>


### PR DESCRIPTION
## Summary
- style trade page intro banner heading and subtitle with `subheading` and `intro`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f3627febc8330babfaea669fc2bcc