### PR TITLE
Add complete About page with hero and journey sections

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,4 +1,209 @@
-<!-- Ready -->
-markdown
-Copy
-Edit
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>About — Cove Bespoke</title>
+
+  <!-- Global styles -->
+  <link rel="stylesheet" href="style/variables.css">
+  <link rel="stylesheet" href="style/base.css">
+  <link rel="stylesheet" href="style/layout.css">
+  <link rel="stylesheet" href="style/sections.css">
+  <link rel="stylesheet" href="style/components.css">
+  <link rel="stylesheet" href="style/buttons.css">
+  <link rel="stylesheet" href="style/forms.css">
+  <link rel="stylesheet" href="style/animations.css">
+
+  <!-- Section styles -->
+  <link rel="stylesheet" href="sections/hero/style.css">
+  <link rel="stylesheet" href="sections/media-left/style.css">
+  <link rel="stylesheet" href="sections/media-right/style.css">
+  <link rel="stylesheet" href="sections/timeline/style.css">
+  <link rel="stylesheet" href="sections/testimonials/style.css">
+  <link rel="stylesheet" href="sections/cta-banner/style.css">
+</head>
+
+<body>
+  <!-- Header -->
+  <div id="header-placeholder"></div>
+
+  <!-- Studio Portrait Hero -->
+  <section class="hero-section">
+    <img class="hero-bg" src="images/about/studio-hero" alt="Cove Bespoke workshop in County Wicklow" loading="lazy" />
+    <div class="hero-content">
+      <h1>Meet Cove Bespoke</h1>
+      <p>Thoughtful design and handmade craftsmanship from County Wicklow.</p>
+      <a href="contact.html" class="btn btn--primary">Start Your Project</a>
+    </div>
+  </section>
+
+  <!-- Our Philosophy (media-left) -->
+  <section id="our-philosophy" class="section media-left" aria-labelledby="philosophy-heading">
+    <h1 id="philosophy-heading" class="media-left__heading">Our Philosophy</h1>
+    <div class="media-left__wrapper">
+      <figure class="media-left__image">
+        <img src="images/about/materials-detail" alt="Close-up of hand-finished joinery and materials" loading="lazy" />
+      </figure>
+      <div class="media-left__content">
+        <p class="subheading">Quiet luxury, crafted for life.</p>
+        <p class="intro">
+          Cove Bespoke creates kitchens and interiors that feel calm, resolved, and timeless. Each project begins with careful listening and ends with a space that fits the way you live. We design with clarity, build with care, and finish with precision.
+        </p>
+        <p class="intro">
+          Everything is made to order in our Wicklow workshop using premium materials and traditional methods supported by modern tooling. The goal is simple. Lasting beauty, everyday ease, and craftsmanship you can feel in every detail.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Design & Visualisation (media-right) -->
+  <section id="design-visuals" class="media-right" aria-labelledby="design-visuals-heading">
+    <div class="media-right__wrapper">
+      <div class="media-right__content">
+        <h2 id="design-visuals-heading" class="media-right__heading">Design With Clarity</h2>
+        <p class="subheading">CAD plans and photorealistic visuals.</p>
+        <p class="intro">
+          We use advanced digital design tools to plan layouts, refine proportions, and present clear 3D visuals. You will see how cabinetry, appliances, lighting, and finishes come together before we cut a single panel.
+        </p>
+        <p class="intro">
+          This is a collaborative stage that removes uncertainty and lets you make confident choices with full visibility of the final result.
+        </p>
+      </div>
+      <figure class="media-right__image">
+        <img src="images/about/cad-visual" alt="Photorealistic CAD render of a bespoke kitchen" loading="lazy" />
+      </figure>
+    </div>
+  </section>
+
+  <!-- Handmade & In-House Finishing (media-left) -->
+  <section id="handmade" class="section media-left" aria-labelledby="handmade-heading">
+    <h1 id="handmade-heading" class="media-left__heading">Handmade In Wicklow</h1>
+    <div class="media-left__wrapper">
+      <figure class="media-left__image">
+        <img src="images/about/workshop-craft" alt="Cabinetmaking by hand in the workshop" loading="lazy" />
+      </figure>
+      <div class="media-left__content">
+        <p class="subheading">From raw boards to final fit.</p>
+        <p class="intro">
+          Every element is built from scratch by a single, focused team. We prepare, assemble, and fine-tune each component by hand. Nothing is off the shelf. This approach delivers strength, accuracy, and a refined finish across every project.
+        </p>
+        <ul class="media-left__list">
+          <li><span>Made to order</span> cabinetry, wardrobes, bars, and media walls</li>
+          <li><span>In-house spray finishing</span> for colour, sheen, and durability</li>
+          <li><span>Premium materials</span> selected for longevity and feel</li>
+          <li><span>Seamless installation</span> handled by the makers themselves</li>
+          <li><span>Serving Wicklow</span> and surrounding areas</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- Timeline: The Bespoke Journey -->
+  <section id="timeline" class="timeline" aria-labelledby="timeline-heading">
+    <h2 id="timeline-heading" class="timeline__heading">Your Bespoke Journey</h2>
+    <div class="timeline__track">
+      <div class="timeline__item">
+        <h3 class="timeline__title">Discovery</h3>
+        <p class="timeline__text">A personal consultation to understand your space, style, and priorities.</p>
+      </div>
+      <div class="timeline__item">
+        <h3 class="timeline__title">Concept Design</h3>
+        <p class="timeline__text">Measured surveys, CAD plans, and visuals to refine layout and materials.</p>
+      </div>
+      <div class="timeline__item">
+        <h3 class="timeline__title">Craft & Finish</h3>
+        <p class="timeline__text">Handmade joinery in our workshop with in-house spray finishing.</p>
+      </div>
+      <div class="timeline__item">
+        <h3 class="timeline__title">Installation</h3>
+        <p class="timeline__text">Delivered and fitted with precision by the makers who built it.</p>
+      </div>
+      <div class="timeline__item">
+        <h3 class="timeline__title">Aftercare</h3>
+        <p class="timeline__text">Ongoing support to keep your space looking and performing at its best.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Testimonials Strip -->
+  <section id="testimonials" class="testimonials" aria-labelledby="testimonials-heading">
+    <h2 id="testimonials-heading" class="testimonials__heading">What Clients Say</h2>
+    <div class="testimonials__wrap">
+      <figure class="testimonial">
+        <blockquote class="testimonial__quote">
+          The design process was clear and enjoyable. The finished kitchen feels calm and beautifully made.
+        </blockquote>
+        <figcaption class="testimonial__meta">— A. Murphy, Dublin</figcaption>
+      </figure>
+
+      <figure class="testimonial">
+        <blockquote class="testimonial__quote">
+          Impeccable craftsmanship and a seamless install. Every line and door feels precise and considered.
+        </blockquote>
+        <figcaption class="testimonial__meta">— S. O’Connor, Wicklow</figcaption>
+      </figure>
+
+      <figure class="testimonial">
+        <blockquote class="testimonial__quote">
+          The visuals helped us make confident decisions. The result is elegant and very practical.
+        </blockquote>
+        <figcaption class="testimonial__meta">— L. Byrne, Greystones</figcaption>
+      </figure>
+    </div>
+  </section>
+
+  <!-- CTA Banner -->
+  <section class="cta-banner" aria-labelledby="cta-heading">
+    <hr class="cta-banner__line" />
+    <h2 id="cta-heading" class="cta-banner__heading">Ready To Begin?</h2>
+    <p class="cta-banner__sub">
+      Share your plans and we will guide you through design, craft, and installation with a personal, end-to-end service.
+    </p>
+    <a href="contact.html" class="btn btn--primary">Book a Consultation</a>
+  </section>
+
+  <!-- Footer -->
+  <div id="footer-placeholder"></div>
+
+  <!-- Optional: header/footer injectors if you are using them elsewhere -->
+  <script>
+    function loadPartial(url, placeholderId) {
+      fetch(url)
+        .then(res => res.text())
+        .then(html => {
+          const parser = new DOMParser();
+          const doc = parser.parseFromString(html, 'text/html');
+          const fragment = document.createDocumentFragment();
+          doc.body.childNodes.forEach(node => fragment.appendChild(node.cloneNode(true)));
+          const placeholder = document.getElementById(placeholderId);
+          placeholder.replaceWith(fragment);
+
+          // Include any stylesheets from the partial's <head>
+          doc.head
+            .querySelectorAll('link[rel="stylesheet"], style')
+            .forEach(el => {
+              const clone = el.cloneNode(true);
+              if (el.tagName.toLowerCase() === 'link') {
+                const exists = Array.from(document.head.querySelectorAll('link'))
+                  .some(l => l.href === clone.href);
+                if (!exists) document.head.appendChild(clone);
+              } else {
+                document.head.appendChild(clone);
+              }
+            });
+
+          // Re-execute any inline or external scripts
+          doc.querySelectorAll('script').forEach(src => {
+            const s = document.createElement('script');
+            if (src.src) { s.src = src.src; } else { s.textContent = src.textContent; }
+            document.body.appendChild(s);
+          });
+        })
+        .catch(err => console.error('Failed to load', url, err));
+    }
+    loadPartial('header/header.html', 'header-placeholder');
+    loadPartial('footer/footer.html', 'footer-placeholder');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add fully fleshed About page with hero, philosophy, design, handmade, timeline, testimonials, and CTA sections
- Load reusable header and footer partials dynamically for consistent site structure
- Remove JPEG assets and references to streamline About page image handling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f3675ae408330b5f5b416c9cbc233